### PR TITLE
mamba env for installations; use compare --avg-containment --ani

### DIFF
--- a/compare_matrices.py
+++ b/compare_matrices.py
@@ -84,7 +84,7 @@ for _, gpath in genome_list:
 subprocess.call(sketch_command, shell=True)
 # Then run sourmash compare with ANI
 save_prefix = 'sourmash_compare_ANI'
-compare_ANI_command = f"sourmash compare -k 21 --ani -o {save_prefix}.cmp "
+compare_ANI_command = f"sourmash compare -k 21 --ani --avg-containment -o {save_prefix}.cmp "
 for _, gpath in genome_list:
     sig_path = os.path.join(sketch_dir, gpath.split('/')[-1]) + '.sig'
     compare_ANI_command += sig_path + ' '

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: phylo-ani
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - sourmash=4.4
+  - biopython
+  - mmh3
+  # temporary: install sourmash 'latest' branch to get `--avg-containment`
+  - rust
+  - pip
+  - pip:
+    - git+https://github.com/sourmash-bio/sourmash@latest


### PR DESCRIPTION
Contains `environment.yml` file for installing from sourmash latest so we can use `--avg-containment` for ANI estimation.

install environment with:
```
mamba env create -f environment.yml
```
activate with: `conda activate phylo-ani`

The matrices now at least look identical between `compare` and using the internal distance function from `sourmash`. There are still discrepancies between sourmash and @mahmudhera's method.